### PR TITLE
Update README.md installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   If you use sbt add the module to libraryDependencies. For example for Lift 2.5.x it will be:
 
 ```
-  "net.liftmodules" %% "validation_2.5" % "1.0-SNAPSHOT"
+  "net.liftmodules" %% "validate_2.5" % "1.0-SNAPSHOT"
 ```
 
   Current development build status:


### PR DESCRIPTION
Currently, the project is named `validate` not `validation`, so in all of the maven-like repositories, that's what resolvers will search for.
